### PR TITLE
refactor: Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "token-contract-as",
   "description": "# Token Smart Contract\n\nThis project contains implementation of token contract similar to ERC20. The contract allows you to launch a new token on top of the NEAR blockchain which users can interact with as if it were any other token -- checking balances, transferring, etc.\n\n[AssemblyScript](https://github.com/AssemblyScript/assemblyscript) compiles strictly typed TypeScript to WebAssembly using Binaryen. See the [AssemblyScript wiki](https://github.com/AssemblyScript/assemblyscript/wiki) for further instructions and documentation.",
+  "license": "(MIT AND Apache-2.0)",
   "version": "0.0.1",
   "scripts": {
     "build": "node asconfig.js",


### PR DESCRIPTION
Running npm/yarn commands would complain that this field wasn't set

This partially addresses https://github.com/near/devx/issues/155