### PR TITLE
Protecting against the Balance Overflow (u64) at the receiver side

### DIFF
--- a/assembly/main.ts
+++ b/assembly/main.ts
@@ -40,6 +40,7 @@ export function transfer(to: string, tokens: u64): boolean {
   const fromAmount = getBalance(context.sender);
   assert(fromAmount >= tokens, "not enough tokens on account");
   balances.set(context.sender, fromAmount - tokens);
+  assert(getBalace(to) <= getBalance(to) + tokens,"overflow at the receiver side");
   balances.set(to, getBalance(to) + tokens);
   return true;
 }
@@ -56,6 +57,7 @@ export function transferFrom(from: string, to: string, tokens: u64): boolean {
   const approvedAmount = allowance(from, to);
   assert(tokens <= approvedAmount, "not enough tokens approved to transfer");
   balances.set(from, fromAmount - tokens);
+  assert(getBalace(to) <= getBalance(to) + tokens,"overflow at the receiver side");
   balances.set(to, getBalance(to) + tokens);
   return true;
 }


### PR DESCRIPTION
The above assert addition checks for the overflow of <u64> at the receiver side. 
As anyone can send any amount of token to anyone (given it's valid with balance checks). If we don't have a check on the overflow attack they possibly can send the required amount of token (u64 Max Value - User's Current Balance) to overflow the user's balance to 0. 
The aforementioned assert condition checks the Balance of user before and after the token addition. In no way we can have reduced token than before, If we get that condition it points that an overflow attack is being carried out. The assert condition precisely captures that and does not allow the transfer.