### PR TITLE
sets node as default in Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,9 +22,9 @@ github:
 
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - before: nvm use default
+  - before: echo "nvm use default" >> ~/.bashrc
     init: yarn && alias near=./node_modules/near-shell/bin/near
-    command: gp open README-Gitpod.md && yarn dev
+    command: source ~/.bashrc gp open README-Gitpod.md && yarn dev
 
 ports:
   - port: 3030

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -24,7 +24,7 @@ github:
 tasks:
   - before: echo "nvm use default" >> ~/.bashrc
     init: yarn && alias near=./node_modules/near-shell/bin/near
-    command: source ~/.bashrc gp open README-Gitpod.md && yarn dev
+    command: source ~/.bashrc; gp open README-Gitpod.md && yarn dev
 
 ports:
   - port: 3030


### PR DESCRIPTION
This PR updates the `.gitpod.yml` file to set node as default. Prior to this, user would have to type `nvm use default` when opening new terminal windows in Gitpod.