### PR TITLE
Use near-cli instead of near-shell

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -23,7 +23,7 @@ github:
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:
   - before: echo "nvm use default" >> ~/.bashrc && nvm use default
-    init: yarn && alias near=./node_modules/near-shell/bin/near
+    init: yarn && alias near=./node_modules/near-cli/bin/near
     command: source ~/.bashrc; gp open README-Gitpod.md && yarn dev
 
 ports:

--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ Standard deploy option
 
 In this second option, the smart contract will get deployed to a specific account created with the NEAR Wallet.
 
-1. Ensure `near-shell` is installed by running:
+1. Ensure `near-cli` is installed by running:
 
        near --version
 
-   If needed, install `near-shell`:
+   If needed, install `near-cli`:
 
-       npm install near-shell -g
+       npm install near-cli -g
 
-2. If you do not have a NEAR account, please create one with [NEAR Wallet](https://wallet.nearprotocol.com). Then, in the project root, login with `near-shell` by following the instructions after this command:
+2. If you do not have a NEAR account, please create one with [NEAR Wallet](https://wallet.nearprotocol.com). Then, in the project root, login with `near-cli` by following the instructions after this command:
 
        near login
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5140,8 +5140,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "filesize": {
       "version": "3.6.1",
@@ -8085,6 +8084,55 @@
         "tweetnacl": "^1.0.1"
       }
     },
+    "near-cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/near-cli/-/near-cli-1.0.1.tgz",
+      "integrity": "sha512-8+EDJXJRfHh3pzi7vSL9aPO+/Xx+iE3Z1Zuelx54SshuQOLpZMbaTO4HlYRmA2VVOAb5MWDADeMCjgSYPSHQsA==",
+      "dev": true,
+      "requires": {
+        "@ledgerhq/hw-transport-node-hid": "^5.15.0",
+        "ascii-table": "0.0.9",
+        "bn.js": "^5.1.1",
+        "bs58": "^4.0.1",
+        "chalk": "^4.0.0",
+        "flagged-respawn": "^1.0.1",
+        "is-ci": "^2.0.0",
+        "jest-environment-node": "^26.0.0",
+        "mixpanel": "^0.11.0",
+        "ncp": "^2.0.0",
+        "near-api-js": "^0.28.0",
+        "near-ledger-js": "^0.1.1",
+        "open": "^7.0.1",
+        "rimraf": "^3.0.0",
+        "stoppable": "^1.1.0",
+        "tcp-port-used": "^1.0.1",
+        "update-notifier": "^4.0.0",
+        "uuid": "^8.0.0",
+        "v8flags": "^3.1.3",
+        "yargs": "^15.0.1"
+      },
+      "dependencies": {
+        "near-api-js": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/near-api-js/-/near-api-js-0.28.0.tgz",
+          "integrity": "sha512-Fq6E+turnwCmAyv3GIQSTlM5cA/wiyh89xL64FfE8fuxXD77QjT3376bkuDg/he0cnhCwLGSctXnxeFs9Q7O1g==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "bn.js": "^5.0.0",
+            "bs58": "^4.0.0",
+            "depd": "^2.0.0",
+            "error-polyfill": "^0.1.2",
+            "http-errors": "^1.7.2",
+            "js-sha256": "^0.9.0",
+            "mustache": "^4.0.0",
+            "node-fetch": "^2.3.0",
+            "text-encoding-utf-8": "^1.0.2",
+            "tweetnacl": "^1.0.1"
+          }
+        }
+      }
+    },
     "near-ledger-js": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/near-ledger-js/-/near-ledger-js-0.1.2.tgz",
@@ -8131,55 +8179,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
-        }
-      }
-    },
-    "near-shell": {
-      "version": "0.24.9",
-      "resolved": "https://registry.npmjs.org/near-shell/-/near-shell-0.24.9.tgz",
-      "integrity": "sha512-z0qCZJNaxoUnFEoYMNUr6TUaaLqNkxhKJciaTIgmMZNHe7IaBOrfDsF2QYuqIEGoPsXs+TN1Z9QRANr1+ffncw==",
-      "dev": true,
-      "requires": {
-        "@ledgerhq/hw-transport-node-hid": "^5.15.0",
-        "ascii-table": "0.0.9",
-        "bn.js": "^5.1.1",
-        "bs58": "^4.0.1",
-        "chalk": "^4.0.0",
-        "flagged-respawn": "^1.0.1",
-        "is-ci": "^2.0.0",
-        "jest-environment-node": "^26.0.0",
-        "mixpanel": "^0.11.0",
-        "ncp": "^2.0.0",
-        "near-api-js": "^0.27.0",
-        "near-ledger-js": "^0.1.1",
-        "open": "^7.0.1",
-        "rimraf": "^3.0.0",
-        "stoppable": "^1.1.0",
-        "tcp-port-used": "^1.0.1",
-        "update-notifier": "^4.0.0",
-        "uuid": "^8.0.0",
-        "v8flags": "^3.1.3",
-        "yargs": "^15.0.1"
-      },
-      "dependencies": {
-        "near-api-js": {
-          "version": "0.27.0",
-          "resolved": "https://registry.npmjs.org/near-api-js/-/near-api-js-0.27.0.tgz",
-          "integrity": "sha512-84tNujERdEEj2uboTHd5CbaAQqOWrQfEFGs+2cdVFYWwcFvMgEMQDwXH0tRan0LRRMTlJXGDsKV8LYf37J9K7A==",
-          "dev": true,
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "bn.js": "^5.0.0",
-            "bs58": "^4.0.0",
-            "depd": "^2.0.0",
-            "error-polyfill": "^0.1.2",
-            "http-errors": "^1.7.2",
-            "js-sha256": "^0.9.0",
-            "mustache": "^4.0.0",
-            "node-fetch": "^2.3.0",
-            "text-encoding-utf-8": "^1.0.2",
-            "tweetnacl": "^1.0.1"
-          }
         }
       }
     },
@@ -10049,8 +10048,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "prompts": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "env-cmd": "^10.1.0",
     "jest": "^26.2.2",
     "near-sdk-as": "^0.4.2",
-    "near-shell": "^0.24.9",
+    "near-cli": "^1.0.1",
     "parcel-bundler": "^1.12.4"
   },
   "dependencies": {
@@ -28,7 +28,7 @@
     "regenerator-runtime": "^0.13.7"
   },
   "jest": {
-    "testEnvironment": "near-shell/test_environment",
+    "testEnvironment": "near-cli/test_environment",
     "testPathIgnorePatterns": [
       "<rootDir>/assembly/",
       "<rootDir>/node_modules/"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5325,10 +5325,10 @@ ncp@^2.0.0:
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
-near-api-js@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.27.0.tgz#d65d4d1059f0d8feb84a56795cb41f5b8c79d68e"
-  integrity sha512-84tNujERdEEj2uboTHd5CbaAQqOWrQfEFGs+2cdVFYWwcFvMgEMQDwXH0tRan0LRRMTlJXGDsKV8LYf37J9K7A==
+near-api-js@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/near-api-js/-/near-api-js-0.28.0.tgz#2d209b407a4356cd10990792c1e6a7958a51b21c"
+  integrity sha512-Fq6E+turnwCmAyv3GIQSTlM5cA/wiyh89xL64FfE8fuxXD77QjT3376bkuDg/he0cnhCwLGSctXnxeFs9Q7O1g==
   dependencies:
     "@types/bn.js" "^4.11.5"
     bn.js "^5.0.0"
@@ -5358,6 +5358,33 @@ near-api-js@^0.29.0:
     node-fetch "^2.3.0"
     text-encoding-utf-8 "^1.0.2"
     tweetnacl "^1.0.1"
+
+near-cli@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/near-cli/-/near-cli-1.0.1.tgz#f261daba930b7c1dec89722c62bb5c2f276926e9"
+  integrity sha512-8+EDJXJRfHh3pzi7vSL9aPO+/Xx+iE3Z1Zuelx54SshuQOLpZMbaTO4HlYRmA2VVOAb5MWDADeMCjgSYPSHQsA==
+  dependencies:
+    ascii-table "0.0.9"
+    bn.js "^5.1.1"
+    bs58 "^4.0.1"
+    chalk "^4.0.0"
+    flagged-respawn "^1.0.1"
+    is-ci "^2.0.0"
+    jest-environment-node "^26.0.0"
+    mixpanel "^0.11.0"
+    ncp "^2.0.0"
+    near-api-js "^0.28.0"
+    open "^7.0.1"
+    rimraf "^3.0.0"
+    stoppable "^1.1.0"
+    tcp-port-used "^1.0.1"
+    update-notifier "^4.0.0"
+    uuid "^8.0.0"
+    v8flags "^3.1.3"
+    yargs "^15.0.1"
+  optionalDependencies:
+    "@ledgerhq/hw-transport-node-hid" "^5.15.0"
+    near-ledger-js "^0.1.1"
 
 near-ledger-js@^0.1.1:
   version "0.1.1"
@@ -5392,33 +5419,6 @@ near-sdk-as@^0.4.2:
     near-vm "^0.0.8"
     semver "^7.1.3"
     visitor-as "^0.1.0"
-
-near-shell@^0.24.9:
-  version "0.24.9"
-  resolved "https://registry.yarnpkg.com/near-shell/-/near-shell-0.24.9.tgz#709180e9cdbcf4f9ab7dfbec51b1dff1007769c9"
-  integrity sha512-z0qCZJNaxoUnFEoYMNUr6TUaaLqNkxhKJciaTIgmMZNHe7IaBOrfDsF2QYuqIEGoPsXs+TN1Z9QRANr1+ffncw==
-  dependencies:
-    ascii-table "0.0.9"
-    bn.js "^5.1.1"
-    bs58 "^4.0.1"
-    chalk "^4.0.0"
-    flagged-respawn "^1.0.1"
-    is-ci "^2.0.0"
-    jest-environment-node "^26.0.0"
-    mixpanel "^0.11.0"
-    ncp "^2.0.0"
-    near-api-js "^0.27.0"
-    open "^7.0.1"
-    rimraf "^3.0.0"
-    stoppable "^1.1.0"
-    tcp-port-used "^1.0.1"
-    update-notifier "^4.0.0"
-    uuid "^8.0.0"
-    v8flags "^3.1.3"
-    yargs "^15.0.1"
-  optionalDependencies:
-    "@ledgerhq/hw-transport-node-hid" "^5.15.0"
-    near-ledger-js "^0.1.1"
 
 near-vm@^0.0.8:
   version "0.0.8"


### PR DESCRIPTION
We're now using
https://www.npmjs.com/package/near-cli
and have a deprecation warning at the top of:
https://www.npmjs.com/package/near-shell

Also the Github has been renamed to:
https://github.com/near/near-cli