### PR TITLE
Fix `yarn start`

### DIFF
--- a/asconfig.json
+++ b/asconfig.json
@@ -2,6 +2,6 @@
   "extends": "near-sdk-as/asconfig.json",
   "options": {
       "measure": true,
-      "binaryFile": "./build/release/contract.wasm"
+      "binaryFile": "./out/main.wasm"
   }
 }


### PR DESCRIPTION
`yarn start` fails because of missing ./out/main.wasm file

I have changed binaryFile path to `./out/main.wasm`

Fixes: #202

yarn start is now working fine
![image](https://user-images.githubusercontent.com/3725386/147826012-fe7addcb-274b-4a7b-a347-859a56c9861f.png)
